### PR TITLE
docs: move decimal_types to config instead of options

### DIFF
--- a/core-concepts/checkpoint-configuration.md
+++ b/core-concepts/checkpoint-configuration.md
@@ -9,6 +9,7 @@ export interface CheckpointConfig {
   optimistic_indexing?: boolean;
   sources?: ContractSourceConfig[];
   templates?: { [key: string]: ContractTemplate };
+  decimal_types?: { [key: string]: { p: number; d: number } };
 }
 
 export interface ContractEventConfig {
@@ -32,4 +33,3 @@ export interface ContractTemplate {
   events: ContractEventConfig[];
 };
 ```
-

--- a/guides/advanced-options.md
+++ b/guides/advanced-options.md
@@ -15,9 +15,6 @@ export interface CheckpointOptions {
   // connection string. If no provided will default to looking up a value in
   // the DATABASE_URL environment.
   dbConnection?: string;
-  // Configuration for decimal types
-  // defaults to Decimal(10, 2), BigDecimal(20, 8)
-  decimalTypes?: { [key: string]: { p: number; d: number } };
 }
 ```
 

--- a/guides/bigint-and-bigdecimal.md
+++ b/guides/bigint-and-bigdecimal.md
@@ -28,23 +28,41 @@ When writing to those fields make sure that you are using JavaScript type that `
 
 ### Custom decimal types
 
-It's possible to define new or to redefine existing decimal types using [advanced options](advanced-options.md).
+It's possible to define new or to redefine existing decimal types using [checkpoint configuration](../core-concepts/checkpoint-configuration.md).
 
 ```typescript
-const checkpoint = new Checkpoint(config, writer, schema, {
-  decimalTypes: {
-    Decimal: {
-      p: 14,
-      d: 10
+import { CheckpointConfig } from "@snapshot-labs/checkpoint";
+
+const config: CheckpointConfig = {
+  network_node_url:
+    "https://starknet-goerli.infura.io/v3/46a5dd9727bf48d4a132672d3f376146",
+  sources: [
+    {
+      contract:
+        "0x04d10712e72b971262f5df09506bbdbdd7f729724030fa909e8c8e7ac2fd0012",
+      start: 185778,
+      deploy_fn: "handleDeploy",
+      events: [
+        {
+          name: "new_post",
+          fn: "handleNewPost",
+        },
+      ],
+      decimal_types: {
+        Decimal: {
+          p: 14,
+          d: 10,
+        },
+        BigDecimal: {
+          p: 20,
+          d: 8,
+        },
+        EvenBiggerDecimal: {
+          p: 40,
+          d: 16,
+        },
+      },
     },
-    BigDecimal: {
-      p: 20,
-      d: 8
-    },
-    EvenBiggerDecimal: {
-      p: 40,
-      d: 16
-    }
-  }
-});
+  ],
+};
 ```


### PR DESCRIPTION
# Summary
Update the documentation regarding the usage of custom Decimal Types within Checkpoint.

## Why have this PR?
The recent change where the `decimal_types` field has been relocated from the options section to the config when initializing Checkpoint.
The aim is to ensure that developers working with Checkpoint are aware of this adjustment and have clear guidance on how to properly configure custom decimal types in their projects.

- Current [CheckpointOptions](https://github.com/checkpoint-labs/checkpoint/blob/6221ea4f5039dbfe41332243e6ac1c31fcda76da/src/types.ts#L16-L33) type in checkpoint
```typescript
export interface CheckpointOptions {
  // Setting to true will trigger reset of database on config changes.
  resetOnConfigChange?: boolean;
  // Set the log output levels for checkpoint. Defaults to Error.
  // Note, this does not affect the log outputs in writers.
  logLevel?: LogLevel;
  // optionally format logs to pretty output.
  // Not recommended for production.
  prettifyLogs?: boolean;
  // Optional interval in milliseconds to check for new blocks.
  fetchInterval?: number;
  // Optional database connection string. For now only accepts PostgreSQL and MySQL/MariaDB
  // connection string. If no provided will default to looking up a value in
  // the DATABASE_URL environment.
  dbConnection?: string;
  // Abis for contracts needed for automatic event parsing
  abis?: Record<string, any>;
}
```
- Current [config schema](https://github.com/checkpoint-labs/checkpoint/blob/6221ea4f5039dbfe41332243e6ac1c31fcda76da/src/schemas.ts#L21-L37) in checkpoint
```typescript
export const checkpointConfigSchema = z.object({
  network_node_url: z.string().url(),
  optimistic_indexing: z.boolean().optional(),
  decimal_types: z
    .record(
      z.object({
        p: z.number(),
        d: z.number()
      })
    )
    .optional(),
  start: z.number().gte(0).optional(),
  tx_fn: z.string().optional(),
  global_events: z.array(contractEventConfigSchema).optional(),
  sources: z.array(contractSourceConfigSchema).optional(),
  templates: z.record(contractTemplateSchema).optional()
});
```

## How to use Decimal Types?
- To configure custom decimal types, include the `decimal_types` field in the configuration like this:
```typescript
import { CheckpointConfig } from "@snapshot-labs/checkpoint";

const config: CheckpointConfig = {
  network_node_url: "",
  sources: [
    {
      contract: "",
      start: 0,
      deploy_fn: "",
      events: [
        {
          name: "",
          fn: "",
        },
      ],
      // Adding decimal_types here
      decimal_types: {
        Decimal: {
          p: 14,
          d: 10,
        },
        BigDecimal: {
          p: 20,
          d: 8,
        },
        EvenBiggerDecimal: {
          p: 40,
          d: 16,
        },
      },
    },
  ],
};
```
- When defining a new decimal type, ensure that it is also defined as a `scalar` in your `schema.gql` file, following the usual pattern for GraphQL types.
- Since Checkpoint uses Knex to handle schema building, you can refer to the official [Knex documentation](https://knexjs.org/guide/schema-builder.html#decimal) for guidance on how to work with decimal types in the database schema. This will help you understand how precision and scale are managed in database tables, ensuring consistency across both the schema and your GraphQL types.