### PR TITLE
Remove mentions of MySQL

### DIFF
--- a/guides/advanced-options.md
+++ b/guides/advanced-options.md
@@ -14,7 +14,7 @@ export interface CheckpointOptions {
   // optionally format logs to pretty output.
   // Not recommended for production.
   prettifyLogs?: boolean;
-  // Optional database connection string. For now only accepts PostgreSQL and MySQL/MariaDB
+  // Optional database connection string. For now only accepts PostgreSQL
   // connection string. If no provided will default to looking up a value in
   // the DATABASE_URL environment.
   dbConnection?: string;

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -25,7 +25,7 @@ yarn
 Checkpoint projects (and by extension this template) require a PostgreSQL database connection to store indexed data. If you have a PostgreSQL server running, then create a copy of the `.env.example` file and name `.env`. Then update the `DATABASE_URL` value in the `.env` file to match the connection string to your database.
 
 {% hint style="info" %}
-If you have Docker on your computer, you can quickly startup a MySQL server by running the following command in a separate terminal:
+If you have Docker on your computer, you can quickly startup a PostgreSQL server by running the following command in a separate terminal:
 
 ```bash
 docker run --name checkpoint-postgres \

--- a/tutorials/part-1-get-started.md
+++ b/tutorials/part-1-get-started.md
@@ -85,7 +85,7 @@ type Post {
 }
 ```
 
-Checkpoint will use the above entity (Post) to generate a MySQL database table named **`posts`** with columns matching the defined fields. It will also generate a list of GraphQL queries to enable querying indexed data.
+Checkpoint will use the above entity (Post) to generate a PostgreSQL database table named **`posts`** with columns matching the defined fields. It will also generate a list of GraphQL queries to enable querying indexed data.
 
 **Step 5: Creating Data Writers**
 


### PR DESCRIPTION
Removes the mentions of `mysql` in the docs because I reckon we only support `postgres`.

Note: I think the syntax in the examples should stay the same between using `mysql` and `postgresql` but not 100% sure?